### PR TITLE
Add GitHub workflow for vaft

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,20 @@
+name: autoupdate
+
+on:
+  schedule:
+    - cron:  '30 5 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt install -y curl jq jsbeautifier
+      - name: Checkout
+        uses: actions/checkout@v2
+      - run: ./scripts/update.sh
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update vaft changes

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+vaft="$(curl -s https://api.github.com/repos/cleanlock/VideoAdBlockForTwitch/commits/master | jq -r "((now - (.commit.author.date | fromdateiso8601) )  / (60*60*24)  | trunc)")"
+
+if [[ $vaft = 0 ]]; then
+    cd ../vaft
+    curl -o vaft-ublock-origin.js https://raw.githubusercontent.com/cleanlock/VideoAdBlockForTwitch/master/remove_video_ads.js
+    echo -e "// This code is directly copied from https://github.com/cleanlock/VideoAdBlockForTwitch (only change is whitespace is removed for the ublock origin script - also indented)\ntwitch-videoad.js application/javascript\n(function() {\nif ( /(^|\.)twitch\.tv$/.test(document.location.hostname) === false ) { return; }\n$(cat vaft-ublock-origin.js)" > vaft-ublock-origin.js
+    echo "})();" >> vaft-ublock-origin.js
+    js-beautify -r vaft-ublock-origin.js
+else
+    echo "Already updated."
+fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -7,6 +7,10 @@ if [[ $vaft = 0 ]]; then
     echo -e "// This code is directly copied from https://github.com/cleanlock/VideoAdBlockForTwitch (only change is whitespace is removed for the ublock origin script - also indented)\ntwitch-videoad.js application/javascript\n(function() {\nif ( /(^|\.)twitch\.tv$/.test(document.location.hostname) === false ) { return; }\n$(cat vaft-ublock-origin.js)" > vaft-ublock-origin.js
     echo "})();" >> vaft-ublock-origin.js
     js-beautify -r vaft-ublock-origin.js
+    curl -o vaft-user.js https://raw.githubusercontent.com/cleanlock/VideoAdBlockForTwitch/master/remove_video_ads.js
+    echo -e "// ==UserScript==\n// @name         TwitchAdSolutions (vaft)\n// @namespace    https://github.com/pixeltris/TwitchAdSolutions\n// @version      5.3.5\n// @description  Multiple solutions for blocking Twitch ads (vaft)\n// @updateURL    https://github.com/pixeltris/TwitchAdSolutions/raw/master/vaft/vaft.user.js\n// @downloadURL  https://github.com/pixeltris/TwitchAdSolutions/raw/master/vaft/vaft.user.js\n// @author       https://github.com/cleanlock/VideoAdBlockForTwitch#credits\n// @match        *://*.twitch.tv/*\n// @run-at       document-start\n// @grant        none\n// ==/UserScript==\n// This code is directly copied from https://github.com/cleanlock/VideoAdBlockForTwitch (only change is whitespace is removed for the ublock origin script - also indented)\n(function() {\n    'use strict';\n$(cat vaft-ublock-origin.js)" > vaft.user.js
+    echo "})();" >> vaft.user.js
+    js-beautify -r vaft-user.js
 else
     echo "Already updated."
 fi


### PR DESCRIPTION
Updating vaft-ublock-origin.js can be tedious. This PR adds a GitHub Action that runs daily. It then runs a shell script that does the following:

1. Access the GitHub API for recent commits to cleanlock/VideoAdBlockForTwitch.
2. If a commit was made today, continue. Otherwise, do nothing.
3. `cd` into vaft and download the latest version of remove_video_ads.js.
4. Add necessary text to the beginning and end of the file.
5. Beautify the file.