### PR TITLE
Added information about TTV LOL PRO v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo aims to provide multiple solutions for blocking Twitch ads.
 
 Proxies are the most reliable way of avoiding ads ([buffering / downtime info](full-list.md#proxy-issues)).
 
-- `TTV LOL PRO` - [code](https://github.com/younesaassila/ttv-lol-pro)
+- `TTV LOL PRO` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol-pro/bpaoeijjlplfjbagceilcgbkcdjbomjd) / [code](https://github.com/younesaassila/ttv-lol-pro)
 - `TTV LOL` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol/ofbbahodfeppoklmgjiokgfdgcndngjm) / [code](https://github.com/TTV-LOL/extensions)
 
 Alternatively:

--- a/full-list.md
+++ b/full-list.md
@@ -3,7 +3,8 @@
 ## Web browser extensions
 
 - `TTV LOL PRO` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol-pro/bpaoeijjlplfjbagceilcgbkcdjbomjd) / [code](https://github.com/younesaassila/ttv-lol-pro)
-  - A fork of the `TTV LOL` extension with sweeping improvements to its ad blocking abilities. (**NOTE: Incompatible with proxies made for TTV LOL.**)
+  - A fork of the `TTV LOL` extension with sweeping improvements to its ad blocking abilities.
+  - **NOTE: Incompatible with proxies made for the original TTV LOL.**
 - `TTV LOL` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol/ofbbahodfeppoklmgjiokgfdgcndngjm) / [code](https://github.com/TTV-LOL/extensions)
   - Uses a proxy on the main m3u8 file to get a stream without ads.
 - `Alternate Player for Twitch.tv` - [chrome](https://chrome.google.com/webstore/detail/alternate-player-for-twit/bhplkbgoehhhddaoolmakpocnenplmhf) / [firefox](https://addons.mozilla.org/en-US/firefox/addon/twitch_5/)

--- a/full-list.md
+++ b/full-list.md
@@ -2,8 +2,8 @@
 
 ## Web browser extensions
 
-- `TTV LOL PRO` - [code](https://github.com/younesaassila/ttv-lol-pro)
-  - A fork of the `TTV LOL` extension with some UX improvements.
+- `TTV LOL PRO` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol-pro/bpaoeijjlplfjbagceilcgbkcdjbomjd) / [code](https://github.com/younesaassila/ttv-lol-pro)
+  - A fork of the `TTV LOL` extension with sweeping improvements to its ad blocking abilities. (**NOTE: Incompatible with proxies made for TTV LOL.**)
 - `TTV LOL` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol/ofbbahodfeppoklmgjiokgfdgcndngjm) / [code](https://github.com/TTV-LOL/extensions)
   - Uses a proxy on the main m3u8 file to get a stream without ads.
 - `Alternate Player for Twitch.tv` - [chrome](https://chrome.google.com/webstore/detail/alternate-player-for-twit/bhplkbgoehhhddaoolmakpocnenplmhf) / [firefox](https://addons.mozilla.org/en-US/firefox/addon/twitch_5/)

--- a/full-list.md
+++ b/full-list.md
@@ -3,7 +3,7 @@
 ## Web browser extensions
 
 - `TTV LOL PRO` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol-pro/bpaoeijjlplfjbagceilcgbkcdjbomjd) / [code](https://github.com/younesaassila/ttv-lol-pro)
-  - A fork of the `TTV LOL` extension with sweeping improvements to its ad blocking abilities.
+  - A fork of the `TTV LOL` extension with sweeping improvements to its ad blocking abilities. Recommended to be used with uBlock Origin.
   - **NOTE: Incompatible with proxies made for the original TTV LOL.**
 - `TTV LOL` - [chrome](https://chrome.google.com/webstore/detail/ttv-lol/ofbbahodfeppoklmgjiokgfdgcndngjm) / [code](https://github.com/TTV-LOL/extensions)
   - Uses a proxy on the main m3u8 file to get a stream without ads.


### PR DESCRIPTION
v2 introduces sweeping changes that differentiate the plugin from TTV LOL, including the use of standard HTTP proxies instead of the custom proxy solution used by the original TTV LOL/TTV LOL PRO v1.

v2 of TTV LOL PRO is in the process of rolling out to addon stores, and is currently available on the Chrome Web Store, which I've added a link to here. I'll introduce another pull once it reaches other addon stores such as the Mozilla addon market.