### PR TITLE
uBO's `twitch-videoad` scriptlet is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Alternatively:
 ## Applying a script (uBlock Origin)
 
 - Navigate to the uBlock Origin Dashboard (the extension options)
-- Under the `My filters` tab add `twitch.tv##+js(twitch-videoad)`.
 - Under the `Settings` tab, enable `I am an advanced user`, then click the cog that appears. Modify the value of `userResourcesLocation` from `unset` to the full url of the solution you wish to use (if a url is already in use, add a space after the existing url). e.g. `userResourcesLocation https://github.com/pixeltris/TwitchAdSolutions/raw/master/vaft/vaft-ublock-origin.js` 
 - To ensure uBlock Origin loads the script I recommend that you disable/enable the uBlock Origin extension (or restart your browser).
 


### PR DESCRIPTION
The `twitch-videoad` scriptlet has been removed a while ago:
https://github.com/gorhill/uBlock/commit/a51130baed745751d325c0618b98f6900c407185#diff-30b28769623e5478a0f68519eda037164484cfb444cb5a8e48518fa7bb32e658L1750