### PR TITLE
Fix `TypeError: "fetch" is read-only`

### DIFF
--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -777,7 +777,7 @@ twitch-videoad.js text/javascript
     localDeviceID = window.localStorage.getItem('local_copy_unique_id');
     function hookFetch() {
         var realFetch = window.fetch;
-        Object.defineProperty(window, "fetch", function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", {writable: true, value: function(url, init, ...args) {
             if (typeof url === 'string') {
                 //Check if squad stream.
                 if (window.location.pathname.includes('/squad')) {
@@ -883,7 +883,7 @@ twitch-videoad.js text/javascript
                 }
             }
             return realFetch.apply(this, arguments);
-        });
+        }});
     }
     hookFetch();
 })();

--- a/vaft/vaft-ublock-origin.js
+++ b/vaft/vaft-ublock-origin.js
@@ -777,7 +777,7 @@ twitch-videoad.js text/javascript
     localDeviceID = window.localStorage.getItem('local_copy_unique_id');
     function hookFetch() {
         var realFetch = window.fetch;
-        window.fetch = function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", function(url, init, ...args) {
             if (typeof url === 'string') {
                 //Check if squad stream.
                 if (window.location.pathname.includes('/squad')) {
@@ -883,7 +883,7 @@ twitch-videoad.js text/javascript
                 }
             }
             return realFetch.apply(this, arguments);
-        };
+        });
     }
     hookFetch();
 })();

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -788,7 +788,7 @@
     localDeviceID = window.localStorage.getItem('local_copy_unique_id');
     function hookFetch() {
         var realFetch = window.fetch;
-        window.fetch = function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", function(url, init, ...args) {
             if (typeof url === 'string') {
                 //Check if squad stream.
                 if (window.location.pathname.includes('/squad')) {
@@ -894,7 +894,7 @@
                 }
             }
             return realFetch.apply(this, arguments);
-        };
+        });
     }
     hookFetch();
 })();

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -788,7 +788,7 @@
     localDeviceID = window.localStorage.getItem('local_copy_unique_id');
     function hookFetch() {
         var realFetch = window.fetch;
-        Object.defineProperty(window, "fetch", function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", {writable: false, value: function(url, init, ...args) {
             if (typeof url === 'string') {
                 //Check if squad stream.
                 if (window.location.pathname.includes('/squad')) {
@@ -894,7 +894,7 @@
                 }
             }
             return realFetch.apply(this, arguments);
-        });
+        }});
     }
     hookFetch();
 })();

--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -788,7 +788,7 @@
     localDeviceID = window.localStorage.getItem('local_copy_unique_id');
     function hookFetch() {
         var realFetch = window.fetch;
-        Object.defineProperty(window, "fetch", {writable: false, value: function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", {writable: true, value: function(url, init, ...args) {
             if (typeof url === 'string') {
                 //Check if squad stream.
                 if (window.location.pathname.includes('/squad')) {

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -402,7 +402,7 @@ twitch-videoad.js text/javascript
     }
     function hookFetch() {
         var realFetch = window.fetch;
-        window.fetch = function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", function(url, init, ...args) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     var deviceId = init.headers['X-Device-Id'];
@@ -456,7 +456,7 @@ twitch-videoad.js text/javascript
                 }
             }
             return realFetch.apply(this, arguments);
-        };
+        });
     }
     function reloadTwitchPlayer(isSeek, isPausePlay) {
         // Taken from ttv-tools / ffz

--- a/video-swap-new/video-swap-new-ublock-origin.js
+++ b/video-swap-new/video-swap-new-ublock-origin.js
@@ -402,7 +402,7 @@ twitch-videoad.js text/javascript
     }
     function hookFetch() {
         var realFetch = window.fetch;
-        Object.defineProperty(window, "fetch", function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", {writable: true, value: function(url, init, ...args) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     var deviceId = init.headers['X-Device-Id'];
@@ -456,7 +456,7 @@ twitch-videoad.js text/javascript
                 }
             }
             return realFetch.apply(this, arguments);
-        });
+        }});
     }
     function reloadTwitchPlayer(isSeek, isPausePlay) {
         // Taken from ttv-tools / ffz

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -413,7 +413,7 @@
     }
     function hookFetch() {
         var realFetch = window.fetch;
-        window.fetch = function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", function(url, init, ...args) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     var deviceId = init.headers['X-Device-Id'];
@@ -467,7 +467,7 @@
                 }
             }
             return realFetch.apply(this, arguments);
-        };
+        });
     }
     function reloadTwitchPlayer(isSeek, isPausePlay) {
         // Taken from ttv-tools / ffz

--- a/video-swap-new/video-swap-new.user.js
+++ b/video-swap-new/video-swap-new.user.js
@@ -413,7 +413,7 @@
     }
     function hookFetch() {
         var realFetch = window.fetch;
-        Object.defineProperty(window, "fetch", function(url, init, ...args) {
+        Object.defineProperty(window, "fetch", {writable: true, value: function(url, init, ...args) {
             if (typeof url === 'string') {
                 if (url.includes('gql')) {
                     var deviceId = init.headers['X-Device-Id'];
@@ -467,7 +467,7 @@
                 }
             }
             return realFetch.apply(this, arguments);
-        });
+        }});
     }
     function reloadTwitchPlayer(isSeek, isPausePlay) {
         // Taken from ttv-tools / ffz


### PR DESCRIPTION
It seems a twitch ([p.js](https://k.twitchcdn.net/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/p.js)?) script  redefines the `window.fetch` with `Object.defineProperty` which makes it read-only (not over-writable with regular assignment).

Only using `Object.defineProperty` will be able to overwrite it.