### PR TITLE
Replace 'Video Ad-Block, for Twitch' by firefox available 'Twitch Adblock (No-Pepe)'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Alternatively:
 - `Alternate Player for Twitch.tv` - [chrome](https://chrome.google.com/webstore/detail/alternate-player-for-twit/bhplkbgoehhhddaoolmakpocnenplmhf) / [firefox](https://addons.mozilla.org/en-US/firefox/addon/twitch_5/)
 - `Purple AdBlock` - [chrome](https://chrome.google.com/webstore/detail/purple-adblock/lkgcfobnmghhbhgekffaadadhmeoindg) / [firefox](https://addons.mozilla.org/en-US/firefox/addon/purpleadblock/) / [code](https://github.com/arthurbolsoni/Purple-adblock/)
 - `AdGuard Extra (Beta)` - [chrome](https://chrome.google.com/webstore/detail/adguard-extra-beta/mglpocjcjbekdckiahfhagndealpkpbj) / [firefox](https://github.com/AdguardTeam/AdGuardExtra/#firefox)
-- `Video Ad-Block, for Twitch` (fork) - [code](https://github.com/cleanlock/VideoAdBlockForTwitch)
+- `Twitch Adblock (No-Pepe) (Fork of "Video Ad-Block, for Twitch")` - [firefox](https://addons.mozilla.org/en-US/firefox/addon/twitch-adblock-no-pepe) / [code](https://github.com/single-right-quote/VideoAdBlockForTwitchNoPepe)
 - `video-swap-new` - see below
 
 [Read this for a full list and descriptions.](full-list.md)

--- a/full-list.md
+++ b/full-list.md
@@ -16,8 +16,8 @@
   - Replaces ad segments with ad-free segments. Proxy fallback which is currently broken. Loading wheel when all methods fail.
 - `AdGuard Extra (Beta)` - [chrome](https://chrome.google.com/webstore/detail/adguard-extra-beta/mglpocjcjbekdckiahfhagndealpkpbj) / [firefox](https://github.com/AdguardTeam/AdGuardExtra/#firefox)
   - Uses segments from the `embed` player during ads. This can get a clean stream faster but suffers from audio sync / freezing issues.
-- `Video Ad-Block, for Twitch` (fork) - [code](https://github.com/cleanlock/VideoAdBlockForTwitch)
-  - Replaces ad segments with ad-free segments. Opt-in proxy fallback during ad segments when the ad-free stream fails locally. Adblocker warning when all methods fail.
+- `Twitch Adblock (No-Pepe) (Fork of "Video Ad-Block, for Twitch")` - [firefox](https://addons.mozilla.org/en-US/firefox/addon/twitch-adblock-no-pepe) / [code](https://github.com/single-right-quote/VideoAdBlockForTwitchNoPepe)
+  - Blocks ads on Twitch by switching to an ad-free version of the stream at 480p during the ad-time and automatically switches back to the original video quality after the ad-time is over. This is 100% done locally, no proxies/VPNs or 3rd party scripts/websites are being used.
 - `ttv_adEraser` - [chrome](https://chrome.google.com/webstore/detail/ttv-aderaser/pjnopimdnmhiaanhjfficogijajbhjnc) / [firefox (manual install)](https://github.com/LeonHeidelbach/ttv_adEraser#mozilla-firefox) / [code](https://github.com/LeonHeidelbach/ttv_adEraser)
   - Switches to the `embed` player when there's ads. May display purple screen if both ads and purple screen show at the same time?
 - `ttv-tools` - [firefox (manual install)](https://github.com/Nerixyz/ttv-tools/releases) / [code](https://github.com/Nerixyz/ttv-tools)


### PR DESCRIPTION
The other alternatives were not available on firefox addons page anymore, this seems to be the current equivalent.


### Description

Was always using the `Video Ad-Block, for Twitch` but was not available anymore on firefox add-ons list anymore.
Tried the replacement listed here but not directly available on Firefox, found this one that seems to be now the 'good' one to use.

I updated the text based on the description from firefox add-ons page.

### Update

Feel free to update anything, was not sure how to describe the add-on and basically just wanted to have a no proxy solution for firefox listed in here.