### PR TITLE
There's no reason to apply this script to vods

### DIFF
--- a/vaft/vaft.user.js
+++ b/vaft/vaft.user.js
@@ -13,6 +13,9 @@
 // ==/UserScript==
 (function() {
     'use strict';
+    if (window.location.href.startsWith("https://www.twitch.tv/videos/")) {
+        return;
+    }
     function declareOptions(scope) {
         scope.AdSignifier = 'stitched';
         scope.ClientID = 'kimne78kx3ncx6brgo4mv6wki5h1ko';


### PR DESCRIPTION
I'm getting freezes in Firefox while watching vods, it says "This page is slowing down Firefox" and the stream stops. Sorry I'm not sure why, front page says `(may suffer from more freezing / playback issues)` so maybe that's it.

It's just silly that it's even running the script when vods don't even have any ads, so this PR prevents that.

If vods ever do get ads, then you can revisit this again and allow the script to run on vods.

note: I'm new to this, I tried using `@exclude` but that doesn't work well when clicking back and forth between vods and live, without refreshing.